### PR TITLE
Add Laravel 13 support

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.4.0
+        uses: dependabot/fetch-metadata@v2.5.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,21 +13,53 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.1, 8.2, 8.3]
-        laravel: [10.*, 11.*, 12.*]
+        php: [8.1, 8.2, 8.3, 8.4]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         exclude:
           - laravel: 11.*
             php: 8.1
           - laravel: 12.*
             php: 8.1
+          - laravel: 13.*
+            php: 8.1
+          - laravel: 13.*
+            php: 8.2
+          - laravel: 10.*
+            php: 8.4
+          - laravel: 11.*
+            php: 8.4
+          - laravel: 12.*
+            php: 8.4
         include:
           - laravel: 10.*
             testbench: 8.*
+            pest: 1.*
+            pest_plugin: 1.*
+            collision: 6.*
+            test_time_package: spatie/pest-plugin-test-time
+            test_time: 1.*
           - laravel: 11.*
-            testbench: ^9.1
+            testbench: ^9.5
+            pest: 2.*
+            pest_plugin: 2.*
+            collision: 8.*
+            test_time_package: spatie/pest-plugin-test-time
+            test_time: 2.*
           - laravel: 12.*
             testbench: 10.*
+            pest: 3.*
+            pest_plugin: 3.*
+            collision: 8.*
+            test_time_package: spatie/pest-plugin-test-time
+            test_time: 2.*
+          - laravel: 13.*
+            testbench: 11.*
+            pest: ^4.4
+            pest_plugin: ^4.1
+            collision: 8.*
+            test_time_package: spatie/test-time
+            test_time: 1.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 
@@ -50,8 +82,15 @@ jobs:
       - name: Install dependencies
         run: |
           composer require --dev "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer require --dev \
+            "pestphp/pest:${{ matrix.pest }}" \
+            "pestphp/pest-plugin-laravel:${{ matrix.pest_plugin }}" \
+            "nunomaduro/collision:${{ matrix.collision }}" \
+            "${{ matrix.test_time_package }}:${{ matrix.test_time }}" \
+            --no-interaction \
+            --no-update
           composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction
 
       - name: Execute tests
-        run: vendor/bin/pest
+        run: vendor/bin/pest --no-coverage

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "opcodesio/spike",
     "description": "Easy user billing for Laravel projects",
+    "license": "MIT",
     "keywords": [
         "opcodes",
         "laravel",
@@ -20,18 +21,18 @@
     "require": {
         "php": "^8.1",
         "arukompas/livewire-charts": "^3.2.0",
-        "illuminate/contracts": "^10.0|^11.7|^12.0",
-        "livewire/livewire": "^3.0",
+        "illuminate/contracts": "^10.0|^11.7|^12.0|^13.0",
+        "livewire/livewire": "^3.8.1",
         "wire-elements/modal": "^2.0"
     },
     "require-dev": {
-        "nunomaduro/collision": "^7.0|^8.0",
-        "orchestra/testbench": "^8.0|^9.1|^10.0",
-        "pestphp/pest": "^2.0|^3.0",
-        "pestphp/pest-plugin-laravel": "^2.0|^3.0",
-        "spatie/pest-plugin-test-time": "^2.2.0",
-        "laravel/cashier": "^15.1.1",
-        "laravel/cashier-paddle": "^2.1"
+        "laravel/cashier": "^15.1.1|^16.5.3",
+        "laravel/cashier-paddle": "^2.1",
+        "nunomaduro/collision": "^6.0|^7.0|^8.0",
+        "orchestra/testbench": "^8.0|^9.5|^10.0|^11.0",
+        "pestphp/pest": "^1.0|^2.0|^3.0|^4.4",
+        "pestphp/pest-plugin-laravel": "^1.0|^2.0|^3.0|^4.1",
+        "spatie/test-time": "^1.3.2"
     },
     "autoload": {
         "psr-4": {
@@ -40,6 +41,9 @@
         }
     },
     "autoload-dev": {
+        "files": [
+            "tests/Support/test-time.php"
+        ],
         "psr-4": {
             "Opcodes\\Spike\\Tests\\": "tests"
         }

--- a/src/Paddle/Subscription.php
+++ b/src/Paddle/Subscription.php
@@ -74,7 +74,7 @@ class Subscription extends \Laravel\Paddle\Subscription implements SpikeSubscrip
      *
      * @return HasMany|Collection|SubscriptionItem[]
      */
-    public function items()
+    public function items(): HasMany
     {
         return $this->hasMany(Cashier::$subscriptionItemModel);
     }

--- a/src/Stripe/Subscription.php
+++ b/src/Stripe/Subscription.php
@@ -69,7 +69,7 @@ class Subscription extends \Laravel\Cashier\Subscription implements SpikeSubscri
      *
      * @return HasMany|Collection|SubscriptionItem[]
      */
-    public function items()
+    public function items(): HasMany
     {
         return $this->hasMany(Cashier::$subscriptionItemModel);
     }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -72,8 +72,11 @@ function createBillable($id = null, bool $withEvents = false)
     return $user;
 }
 
-function setupMonthlySubscriptionPlan(array|int $provides, int $price_in_cents = 0, string $payment_provider_price_id = null)
-{
+function setupMonthlySubscriptionPlan(
+    array|int $provides,
+    int $price_in_cents = 0,
+    ?string $payment_provider_price_id = null,
+) {
     if (is_int($provides)) {
         $provides = [CreditAmount::make($provides)];
     }
@@ -92,8 +95,11 @@ function setupMonthlySubscriptionPlan(array|int $provides, int $price_in_cents =
     return Spike::findSubscriptionPlan($payment_provider_price_id);
 }
 
-function setupYearlySubscriptionPlan(array|int $provides, int $price_in_cents = 0, string $payment_provider_price_id = null)
-{
+function setupYearlySubscriptionPlan(
+    array|int $provides,
+    int $price_in_cents = 0,
+    ?string $payment_provider_price_id = null,
+) {
     if (is_int($provides)) {
         $provides = [CreditAmount::make($provides)];
     }

--- a/tests/Support/test-time.php
+++ b/tests/Support/test-time.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Spatie\PestPluginTestTime;
+
+use Carbon\Carbon;
+use Spatie\TestTime\TestTime as BaseTestTime;
+
+if (! class_exists(TestTime::class)) {
+    /** @mixin BaseTestTime|\Carbon\Carbon */
+    class TestTime
+    {
+        public function freeze(Carbon|string|null $time = null, string $format = 'Y-m-d H:i:s'): Carbon
+        {
+            if ($time instanceof Carbon) {
+                return BaseTestTime::freeze($time);
+            }
+
+            if ($time === null) {
+                return BaseTestTime::freeze();
+            }
+
+            return BaseTestTime::freeze($format, $time);
+        }
+
+        public function __call(string $name, array $arguments): mixed
+        {
+            return BaseTestTime::$name(...$arguments);
+        }
+    }
+}
+
+if (! function_exists(__NAMESPACE__.'\\testTime')) {
+    function testTime(): TestTime
+    {
+        return new TestTime();
+    }
+}


### PR DESCRIPTION
## Summary
- Add Laravel 13 compatible dependency constraints and CI matrix entries
- Add Pest TestTime compatibility shim for spatie/test-time
- Match Cashier subscription item relation signatures

## Tests
- vendor/bin/pest --no-coverage
- composer validate --strict /private/tmp/spike-composer-validate/composer.json